### PR TITLE
Port over mock market from previous PR

### DIFF
--- a/contracts/MarketAPI.sol
+++ b/contracts/MarketAPI.sol
@@ -59,4 +59,10 @@ contract MarketAPI{
     function get_deal_activation(MarketTypes.GetDealActivationParams memory params) public pure returns (MarketTypes.GetDealActivationReturn memory) {
         return MarketTypes.GetDealActivationReturn(1, 1);
     }
+
+    function publish_deal(bytes memory raw_auth_params, address callee) public {
+        // calls standard filecoin receiver on message authentication api method number
+        (bool success, ) = callee.call(abi.encodeWithSignature("handle_filecoin_method(uint64,uint64,bytes)", 0, 2643134072, raw_auth_params));
+        require(success, "client contract failed to authorize deal publish");
+    }
 }


### PR DESCRIPTION
Just porting over this PR from before the repo move: https://github.com/Zondax/fevm-solidity-precompiles/pull/23/files

I've got a tiny mock market api and tests over in the [client-contract](https://github.com/lotus-web3/client-contract) project so this code should probably work.